### PR TITLE
[BAC-943] v1.0.0: Build staging branch

### DIFF
--- a/scripts/version-and-build-staging.sh
+++ b/scripts/version-and-build-staging.sh
@@ -14,26 +14,26 @@ git config --global user.email "ci@dydx.exchange"
 git config --global user.name "circle_ci"
 
 # Get version and tag
-version=`cat VERSION`
+version=`cat VERSION_STAGING`
 git tag v${version}
 
 # Bump version
 new_version="$((version + 1))"
-echo $new_version > './VERSION'
-git add VERSION
-git commit -m "Prep VERSION for next build v$new_version [ci skip]"
-git push origin master
+echo $new_version > './VERSION_STAGING'
+git add VERSION_STAGING
+git commit -m "Prep VERSION_STAGING for next build v$new_version [ci skip]"
+git push origin staging
 git push --tags
 
 # Build docker image
-docker build -t $SERVICE_NAME:v$version . --build-arg NPM_TOKEN=${NPM_TOKEN}
+docker build -t $SERVICE_NAME:v$version-staging . --build-arg NPM_TOKEN=${NPM_TOKEN}
 
 # Push to ECR
 $(aws ecr get-login --no-include-email --region us-east-1)
-docker tag $SERVICE_NAME:v$version $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$SERVICE_NAME:v$version
-docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$SERVICE_NAME:v$version
+docker tag $SERVICE_NAME:v$version-staging $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$SERVICE_NAME:v$version-staging
+docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$SERVICE_NAME:v$version-staging
 
 # Push to DockerHub
-docker tag $SERVICE_NAME:v$version dydxprotocol/$SERVICE_NAME:v$version
+docker tag $SERVICE_NAME:v$version-staging dydxprotocol/$SERVICE_NAME:v$version-staging
 docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
 docker push dydxprotocol/$SERVICE_NAME


### PR DESCRIPTION
Publish to the docker repositories a container for the staging branch. Will need to update cookbook to make these versions deployable. And then update each service's circleci config so run this script on the staging branch.

Note: there is a separate version file and version numbering for staging. I think this is necessary as commits can be merged independently to master and staging but we'll have to have engineers adjust to it (not the same version numbers for prod and staging anymore)

Publish as breaking change as VERSION_STAGE needs to be added now

Also I think we should upgrade it to X.0.0 over 0.X.0