### PR TITLE
v0.2.0: add more lint checks to NSB-dev (warn on only test, error on async with no await)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'no-only-tests'],
   extends: [
     'eslint:recommended',
     'airbnb-typescript/base',
@@ -42,6 +42,7 @@ module.exports = {
     '**/coverage/**/*.js',
   ],
   rules: {
+    'no-only-tests/no-only-tests': 'warn',
     'arrow-body-style': 'off',
     'class-methods-use-this': 'off',
     'consistent-return': 'off', // Annoying when return type is Promise<void>. Not as helpful for TypeScript anyway.
@@ -164,5 +165,6 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-var-requires': 'warn',
+    '@typescript-eslint/require-await': 'error',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/node-service-base-dev",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2347,6 +2347,11 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "eslint-plugin-no-only-tests": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz",
+      "integrity": "sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ=="
     },
     "eslint-scope": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/node-service-base-dev",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Shared development configuration and utilities for Node services",
   "main": "build/index.js",
   "scripts": {
@@ -34,6 +34,7 @@
     "eslint": "^7.8.0",
     "eslint-config-airbnb-typescript": "^9.0.0",
     "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-no-only-tests": "2.4.0",
     "jest": "^26.6.3",
     "nodemon": "^2.0.4",
     "typescript": "^4.0.2"


### PR DESCRIPTION
- https://www.npmjs.com/package/eslint-plugin-no-only-tests
- https://eslint.org/docs/rules/require-await