### PR TITLE
v0.2.6 use no-verify in dydx-ci [BAC-2557]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/node-service-base-dev",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/node-service-base-dev",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Shared development configuration and utilities for Node services",
   "main": "build/index.js",
   "scripts": {

--- a/scripts/version-and-build.sh
+++ b/scripts/version-and-build.sh
@@ -26,7 +26,7 @@ git tag v${version}
 new_version="$((version + 1))"
 echo $new_version > './VERSION'
 git add VERSION
-git commit -m "Prep VERSION for next build v$new_version [ci skip]"
+git commit -m "Prep VERSION for next build v$new_version [ci skip]" --no-verify
 git push origin master
 git push --tags
 


### PR DESCRIPTION
The [pre-commit hook](https://github.com/dydxprotocol/roundtable/commit/09668278a4305809b1f8330503fdecb36b649a73) is causing the version-and-build script to fail with `fatal: cannot run .git/hooks/pre-commit: No such file or directory`. Bypass it with adding a flag that bypasses pre-commit hook checks