### PR TITLE
v0.2.9: push image with correct tag [BAC-2929]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/node-service-base-dev",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/node-service-base-dev",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Shared development configuration and utilities for Node services",
   "main": "build/index.js",
   "scripts": {

--- a/scripts/version-and-build.sh
+++ b/scripts/version-and-build.sh
@@ -36,7 +36,7 @@ docker build -t $SERVICE_NAME:v$version . --build-arg NPM_TOKEN=${NPM_TOKEN}
 # Push to DockerHub
 docker tag $SERVICE_NAME:v$version dydxprotocol/$SERVICE_NAME:v$version
 docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-docker push dydxprotocol/$SERVICE_NAME
+docker push dydxprotocol/$SERVICE_NAME:v$version
 
 # Push to ECR
 for region in us-east-1 ap-northeast-1


### PR DESCRIPTION
After upgrading Docker from version 17.09.0-ce to version 20.10.14, we now have to explicitly tell Docker which tag should be pushed, otherwise it defaults to `latest` and can't find the image:

```
Successfully built 27d6f71b56f8
Successfully tagged *********:v781
+ docker tag *********:v781 dydxprotocol/*********:v781
+ docker login -u *********** -p ************************************
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /root/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
+ docker push dydxprotocol/*********
Using default tag: latest
The push refers to repository [docker.io/dydxprotocol/*********]
tag does not exist: dydxprotocol/*********:latest
```

I re-ran the job with SSH using this change and it passed:

```
64a0cf73263d:~/build# docker push dydxprotocol/$SERVICE_NAME
Using default tag: latest
The push refers to repository [docker.io/dydxprotocol/stacks]
tag does not exist: dydxprotocol/stacks:latest
64a0cf73263d:~/build# docker push dydxprotocol/$SERVICE_NAME:v$version
The push refers to repository [docker.io/dydxprotocol/stacks]
4960979fa4fe: Pushed 
93308e05734e: Pushed 
...
```